### PR TITLE
Fix AggregatorActor

### DIFF
--- a/src/main/java/ar/edu/itba/tav/game_rooms/utils/AggregatorActor.java
+++ b/src/main/java/ar/edu/itba/tav/game_rooms/utils/AggregatorActor.java
@@ -109,6 +109,10 @@ public class AggregatorActor<T> extends AbstractActor {
      * Handles the aggregation request.
      */
     private void handleAggregationRequest() {
+        if (this.actors.isEmpty()) {
+            terminateSuccessful();
+            return;
+        }
         // Send the request to each actor
         this.actors.forEach(actorRef -> actorRef.tell(this.request, this.getSelf()));
         this.timeoutTask = this.getContext().getSystem()


### PR DESCRIPTION
- Avoid waiting for results if the list of actors to query is empty
	- In this case, return the "successful" message without setting the scheduler